### PR TITLE
Adds mouse wheel input, and a 0...1 float output value

### DIFF
--- a/addons/fkeyz_knob/knob.gd
+++ b/addons/fkeyz_knob/knob.gd
@@ -39,18 +39,17 @@ signal dial_rotated(degrees: float, value: float)
 func _ready() -> void: _dial.rotation_degrees = start_degrees
 
 func _input(event: InputEvent) -> void:
-	if event is InputEventMouseButton and event.button_index == 1:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
 		if !event.pressed:
 			_dragging = false
 
 func _on_area_2d_input_event(viewport: Node, event: InputEvent, shape_idx: int) -> void:
-	if event is InputEventMouseButton and event.button_index == 1:
-		if event.pressed:
+	if event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 			_dragging = true
 			_mouse_position_start = Vector2(0, event.position.y)
 			_rotation_degrees_start = _dial.rotation_degrees
-	elif event is InputEventMouseButton:
-		if event.button_index == MOUSE_BUTTON_WHEEL_UP and event.is_released():
+		elif event.button_index == MOUSE_BUTTON_WHEEL_UP and event.is_released():
 			var relative_rotation = _dial.rotation_degrees + wheel_increment
 			var clamped_rotation = clampf(relative_rotation, minimum_degrees, maximum_degrees)
 			_dial.rotation_degrees = clamped_rotation
@@ -75,5 +74,5 @@ func _physics_process(delta: float) -> void:
 
 func _calculate_value(degree: float):
 	var adjustedAngle = degree - minimum_degrees
-	var value:float = adjustedAngle / (maximum_degrees - minimum_degrees)
+	var value: float = adjustedAngle / (maximum_degrees - minimum_degrees)
 	return value

--- a/addons/fkeyz_knob/knob.gd
+++ b/addons/fkeyz_knob/knob.gd
@@ -25,7 +25,7 @@ class_name Knob extends Control
 		if not is_inside_tree(): await ready
 		maximum_degrees = clampf(value, minimum_degrees, 180.0) 
 ## The change in degrees per mouse wheel event. Negative values will make it work in reverse. Can be set to zero to prevent the effect.
-@export var wheel_increment := 10
+@export_range(-360, 360, 0.1, "degrees") var wheel_increment := 10
 
 @onready var _dial: Sprite2D = %Dial
 

--- a/addons/fkeyz_knob/plugin.cfg
+++ b/addons/fkeyz_knob/plugin.cfg
@@ -3,5 +3,5 @@
 name="fkeyzKnob"
 description="Knob UI element."
 author="fkeyz"
-version="1.0"
+version="1.1"
 script="fkeyz_knob_plugin.gd"


### PR DESCRIPTION
Mouse wheel input is now supported. Works when the user hovers the mouse cursor over the knob element and sends either a MOUSE_BUTTON_WHEEL_UP or MOUSE_BUTTON_WHEEL_DOWN input event by scrolling the mouse's wheel. Upon receiving the event, the `_dial.rotation_degrees` variable is incremented or decremented by the `wheel_increment` value, and also clamped within the minimum and maximum degrees permitted.

The `dial_rotated` signal also now outputs a float value ranging from 0 to 1. This represents the position of the dial between the minimum (at zero) and maximum (at one) degrees settings. Useful if you aren't concerned about the degrees but just want to know what percentage to maximum the dial is set to when the user is done.

The project has been bumped to version 1.1 as well, for what it's worth.